### PR TITLE
Fix #67: case-insensitive word-boundary matching in DetermineBestMatch

### DIFF
--- a/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
+++ b/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
@@ -914,7 +914,7 @@ namespace MountainProjectAPI
             if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(query))
                 return false;
 
-            string pattern = $@"(^|\s){Regex.Escape(query)}($|\s)";
+            string pattern = $@"(?<![-'\w]){Regex.Escape(query)}(?![-'\w])";
             return Regex.IsMatch(text, pattern, RegexOptions.IgnoreCase);
         }
 

--- a/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
+++ b/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
@@ -914,7 +914,7 @@ namespace MountainProjectAPI
             if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(query))
                 return false;
 
-            string pattern = $@"\b{Regex.Escape(query)}\b";
+            string pattern = $@"(^|\s){Regex.Escape(query)}($|\s)";
             return Regex.IsMatch(text, pattern, RegexOptions.IgnoreCase);
         }
 

--- a/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
+++ b/MountainProjectAPI/Functions/MountainProjectDataSearch.cs
@@ -701,28 +701,25 @@ namespace MountainProjectAPI
                 return null;
 
             //=============== CHOOSE THE BEST MATCH ===============
-            //First priority: items where the name matches the search query exactly CASE SENSITIVE
-            List<MPObject> filteredItems = allMatches.Where(p => Utilities.StringsEqual(searchQuery, p.Name, false)).ToList();
+            //First priority: items where the name matches the search query exactly (case-insensitive)
+            List<MPObject> filteredItems = allMatches.Where(p => Utilities.StringsEqual(searchQuery, p.Name)).ToList();
 
-            //Second priority: items where the name matches the search query exactly (but case-insensitive)
-            if (!filteredItems.Any())
-                filteredItems = allMatches.Where(p => Utilities.StringsEqual(searchQuery, p.Name)).ToList();
-
-            //Third priority: items where the name matches the FILTERED (no symbols or spaces, case insensitive) search query exactly
+            //Second priority: items where the name matches the FILTERED (no symbols or spaces, case insensitive) search query exactly
             if (!filteredItems.Any())
                 filteredItems = allMatches.Where(p => Utilities.StringsEqual(Utilities.FilterStringForMatch(searchQuery), p.NameForMatch)).ToList();
 
-            //[IN THE FUTURE]Fourth priority: items with a levenshtein distance less than 3
+            //[IN THE FUTURE]Third priority: items with a levenshtein distance less than 3
 
-            //Fifth priority: items where the name contains the search query CASE SENSITIVE
+            //Fourth priority: items where the name contains the search query as a whole-word phrase (case-insensitive).
+            //Word boundaries prevent eg "East Face" from matching "Northeast Face"
             if (!filteredItems.Any())
-                filteredItems = allMatches.Where(p => Utilities.StringContains(p.Name, searchQuery, false)).ToList();
+                filteredItems = allMatches.Where(p => ContainsAsWord(p.Name, searchQuery)).ToList();
 
-            //Sixth priority: items where the name contains the search query (case-insensitive)
+            //Fifth priority: items where the name contains the search query (case-insensitive)
             if (!filteredItems.Any())
                 filteredItems = allMatches.Where(p => Utilities.StringContains(p.Name, searchQuery)).ToList();
 
-            //Seventh priority: items where the name contains the FITLERED search query (case-insensitive)
+            //Sixth priority: items where the name contains the FITLERED search query (case-insensitive)
             if (!filteredItems.Any())
                 filteredItems = allMatches.Where(p => Utilities.StringContains(p.NameForMatch, Utilities.FilterStringForMatch(searchQuery))).ToList();
 
@@ -886,6 +883,16 @@ namespace MountainProjectAPI
             }
 
             return results;
+        }
+
+        // Returns true if text contains query as a whole-word phrase (delimited by word boundaries on both sides), case-insensitively
+        private static bool ContainsAsWord(string text, string query)
+        {
+            if (string.IsNullOrEmpty(text) || string.IsNullOrEmpty(query))
+                return false;
+
+            string pattern = $@"\b{Regex.Escape(query)}\b";
+            return Regex.IsMatch(text, pattern, RegexOptions.IgnoreCase);
         }
 
         private static void WriteToConsole(string message)

--- a/UnitTests/SearchTests.cs
+++ b/UnitTests/SearchTests.cs
@@ -46,6 +46,7 @@ namespace UnitTests
             { "Landjäger", "/route/117251258/landjager" }, //Diacritical marks optional
             { "Landjager", "/route/117251258/landjager" }, //Diacritical marks optional
             { "Alexisizer", "/route/106657518/alexisizer" }, //There is an "Alexisizer" area and an "Alexisizer" route. This is to make sure the route is picked
+            { "Darkness at Noon", "/route/106070861/darkness-at-noon" }, //Issue #67: case-insensitive matching. Most popular variant is "Darkness At Noon" (capital A) but query uses lowercase "at"
             { "Wood, HP40", "/route/106286494/the-wood" }, //Test for nickname "HP40"
             { "Golden, RRG", "/route/108521478/golden-ticket" }, //Test for nickname "RRG"
         };


### PR DESCRIPTION
Fixes #67.

Searching "Darkness at Noon" was returning route 112124749 (413k pop according to XML) instead of 106070861 (669k pop) because the case-sensitive tier 1 only admitted lowercase variants. Removed that tier and let case-insensitive equality + popularity filter handle it.

Tier 5's case-sensitive contains was the only thing keeping "East Face" from matching "Northeast Face", but it seemed to work by accident (MP happens to write "Northeast" with a lowercase "east" inside). Replaced that with a \b word-boundary regex so the behavior is preserved on purpose.

Added Darkness at Noon to testCriteria_search.